### PR TITLE
[codex] Fix Qwen forecast tail dtype handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 *.suo
 *.user
 *.VC.db
+.codex/

--- a/spectrum_qwen/forward_qwen.py
+++ b/spectrum_qwen/forward_qwen.py
@@ -46,6 +46,20 @@ def _reconstruct_qwen_output(
     return out_sample.reshape(orig_shape)[:, :, :, : model_input.shape[-2], : model_input.shape[-1]]
 
 
+def _sanitize_forecast_feature(
+    feature: torch.Tensor,
+    target_dtype: torch.dtype,
+) -> torch.Tensor:
+    if not target_dtype.is_floating_point:
+        return feature.to(dtype=target_dtype).contiguous()
+
+    finfo = torch.finfo(target_dtype)
+    feature = feature.to(torch.float32)
+    feature = torch.nan_to_num(feature, nan=0.0, posinf=finfo.max, neginf=finfo.min)
+    feature = feature.clamp(min=finfo.min, max=finfo.max)
+    return feature.to(dtype=target_dtype).contiguous()
+
+
 
 def _run_actual_forward(
     core: Any,
@@ -55,7 +69,7 @@ def _run_actual_forward(
     *args: Any,
     **kwargs: Any,
 ) -> Any:
-    captured: dict[str, torch.Tensor] = {}
+    captured: dict[str, Any] = {}
 
     def capture_pre_norm(_module: Any, hook_args: tuple[Any, ...]) -> None:
         if not hook_args:
@@ -63,6 +77,7 @@ def _run_actual_forward(
         hidden = hook_args[0]
         target_device, target_dtype = resolve_cache_target(hidden, state.config.cache_device)
         captured["feature"] = hidden.detach().to(device=target_device, dtype=target_dtype)
+        captured["model_feature_dtype"] = hidden.dtype
 
     handle = core.norm_out.register_forward_pre_hook(capture_pre_norm)
     try:
@@ -83,6 +98,7 @@ def _run_actual_forward(
         sigma=runtime.current_sigma,
         time_coord=runtime.current_time_coord,
         feature=feature,
+        model_feature_dtype=captured.get("model_feature_dtype"),
         output_factory=build_output_factory(out),
     )
     log_debug(
@@ -110,7 +126,9 @@ def _run_forecast_forward(
         raise RuntimeError("output factory missing before forecast")
     pred = state.forecaster.predict(runtime.current_time_coord)
 
-    pred = pred.to(device=hidden_states.device, dtype=hidden_states.dtype)
+    target_dtype = state.model_feature_dtype or pred.dtype
+    pred = pred.to(device=hidden_states.device)
+    pred = _sanitize_forecast_feature(pred, target_dtype)
     temb = _call_time_text_embed(core, timestep, pred, additional_t_cond)
     out_sample = core.proj_out(core.norm_out(pred, temb))
     out_sample = _reconstruct_qwen_output(core, hidden_states, out_sample)

--- a/spectrum_qwen/state.py
+++ b/spectrum_qwen/state.py
@@ -27,6 +27,7 @@ class QwenSpectrumState:
     history_sigmas: list[float] = field(default_factory=list)
     history_features: list[torch.Tensor] = field(default_factory=list)
     forecaster: ChebyshevSpectrumForecaster = field(init=False)
+    model_feature_dtype: torch.dtype | None = None
     actual_count: int = 0
     forecast_count: int = 0
     consecutive_forecasts: int = 0
@@ -47,6 +48,7 @@ class QwenSpectrumState:
         self.history_sigmas.clear()
         self.history_features.clear()
         self.forecaster.reset()
+        self.model_feature_dtype = None
         self.actual_count = 0
         self.forecast_count = 0
         self.consecutive_forecasts = 0
@@ -61,11 +63,14 @@ class QwenSpectrumState:
         sigma: float,
         time_coord: float,
         feature: torch.Tensor,
+        model_feature_dtype: torch.dtype | None,
         output_factory: Callable[[Any, bool], Any] | None,
     ) -> None:
         self.actual_count += 1
         self.consecutive_forecasts = 0
         self.forecaster.update(time_coord, feature)
+        if model_feature_dtype is not None:
+            self.model_feature_dtype = model_feature_dtype
         self.history_sigmas.append(float(sigma))
         self.history_features.append(feature)
         if len(self.history_features) > self.config.history_points:

--- a/tests/test_forward_qwen.py
+++ b/tests/test_forward_qwen.py
@@ -4,7 +4,13 @@ import unittest
 
 import torch
 
-from spectrum_qwen.forward_qwen import _reconstruct_qwen_output
+from spectrum_qwen.config import QwenSpectrumConfig
+from spectrum_qwen.forward_qwen import (
+    _reconstruct_qwen_output,
+    _run_forecast_forward,
+    _sanitize_forecast_feature,
+)
+from spectrum_qwen.state import QwenSpectrumRuntime, QwenSpectrumState
 
 
 class _FakeCore:
@@ -17,6 +23,38 @@ class _FakeCore:
         return tokenized_x, img_ids, orig_shape
 
 
+class _ForecastCore(_FakeCore):
+    def __init__(self) -> None:
+        self.seen_norm_dtype: torch.dtype | None = None
+
+    def time_text_embed(self, timestep: torch.Tensor, hidden_states: torch.Tensor, additional_t_cond):
+        return torch.zeros(
+            (hidden_states.shape[0], hidden_states.shape[-1]),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+
+    def norm_out(self, hidden_states: torch.Tensor, temb: torch.Tensor) -> torch.Tensor:
+        self.seen_norm_dtype = hidden_states.dtype
+        return hidden_states
+
+    def proj_out(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        extra = torch.zeros(
+            (hidden_states.shape[0], 2, hidden_states.shape[-1]),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        return torch.cat([hidden_states, extra], dim=1)
+
+
+class _FakeForecaster:
+    def __init__(self, prediction: torch.Tensor) -> None:
+        self.prediction = prediction
+
+    def predict(self, time_coord: float) -> torch.Tensor:
+        return self.prediction
+
+
 class ReconstructQwenOutputTest(unittest.TestCase):
     def test_reconstructs_original_spatial_shape_with_crop_and_extra_tokens(self) -> None:
         core = _FakeCore()
@@ -26,6 +64,80 @@ class ReconstructQwenOutputTest(unittest.TestCase):
         reconstructed = _reconstruct_qwen_output(core, model_input, out_sample)
 
         self.assertEqual(tuple(reconstructed.shape), tuple(model_input.shape))
+
+    def test_forecast_uses_recorded_model_hidden_dtype_not_outer_input_dtype(self) -> None:
+        core = _ForecastCore()
+        state = QwenSpectrumState(config=QwenSpectrumConfig())
+        state.output_factory = lambda sample, return_dict: sample
+        state.model_feature_dtype = torch.bfloat16
+        state.forecaster = _FakeForecaster(torch.ones((1, 4, 8), dtype=torch.float32))  # type: ignore[assignment]
+
+        runtime = QwenSpectrumRuntime(
+            config=state.config,
+            current_step_index=3,
+            total_steps=10,
+            current_sigma=1.0,
+            current_time_coord=0.0,
+            decision_actual=False,
+            forecast_reason="forecast",
+            branch_key=(0,),
+        )
+
+        result = _run_forecast_forward(
+            core,
+            state,
+            runtime,
+            hidden_states=torch.zeros((1, 2, 1, 4, 2), dtype=torch.float16),
+            timestep=torch.tensor([1.0], dtype=torch.float32),
+            additional_t_cond=None,
+        )
+
+        self.assertEqual(core.seen_norm_dtype, torch.bfloat16)
+        self.assertEqual(tuple(result.shape), (1, 2, 1, 4, 2))
+
+    def test_forecast_sanitizer_clamps_nonfinite_values_for_target_dtype(self) -> None:
+        feature = torch.tensor([0.0, float("nan"), float("inf"), -float("inf")], dtype=torch.float32)
+
+        sanitized = _sanitize_forecast_feature(feature, torch.float16)
+
+        self.assertEqual(sanitized.dtype, torch.float16)
+        self.assertTrue(torch.isfinite(sanitized).all().item())
+
+    def test_forecast_falls_back_to_prediction_dtype_when_model_dtype_is_missing(self) -> None:
+        core = _ForecastCore()
+        state = QwenSpectrumState(config=QwenSpectrumConfig())
+        state.output_factory = lambda sample, return_dict: sample
+        state.forecaster = _FakeForecaster(torch.ones((1, 4, 8), dtype=torch.float32))  # type: ignore[assignment]
+
+        runtime = QwenSpectrumRuntime(
+            config=state.config,
+            current_step_index=3,
+            total_steps=10,
+            current_sigma=1.0,
+            current_time_coord=0.0,
+            decision_actual=False,
+            forecast_reason="forecast",
+            branch_key=(0,),
+        )
+
+        _run_forecast_forward(
+            core,
+            state,
+            runtime,
+            hidden_states=torch.zeros((1, 2, 1, 4, 2), dtype=torch.float16),
+            timestep=torch.tensor([1.0], dtype=torch.float32),
+            additional_t_cond=None,
+        )
+
+        self.assertEqual(core.seen_norm_dtype, torch.float32)
+
+    def test_state_reset_clears_recorded_model_hidden_dtype(self) -> None:
+        state = QwenSpectrumState(config=QwenSpectrumConfig())
+        state.model_feature_dtype = torch.bfloat16
+
+        state.reset()
+
+        self.assertIsNone(state.model_feature_dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- record the real pre-`norm_out` hidden-state dtype during actual Qwen steps and reuse it on forecast steps
- sanitize forecasted features before casting them into the Qwen tail dtype to avoid handing NaN, Inf, or out-of-range values into `time_text_embed -> norm_out -> proj_out`
- add focused coverage for recorded-dtype handoff, missing-dtype fallback, sanitizer behavior, and reset cleanup
- ignore the transient `.codex/` directory in `.gitignore`

## Root Cause
Issue #9 fails at the first forecasted step after warmup because the forecast branch was casting predicted features to `hidden_states.dtype`, which is the outer latent input dtype. Native Qwen keys `time_text_embed` off the inner transformer hidden-state dtype seen before `norm_out`, so the forecast path could hand the tail a mismatched dtype after several successful real forwards.

## Validation
- `python3 -m py_compile /tmp/ComfyUI-Spectrum-Qwen-Proper-issue9/spectrum_qwen/state.py /tmp/ComfyUI-Spectrum-Qwen-Proper-issue9/spectrum_qwen/forward_qwen.py /tmp/ComfyUI-Spectrum-Qwen-Proper-issue9/tests/test_forward_qwen.py`
- `git diff --check`
- `/ouroboros:qa` verdict: PASS at 0.86

## Notes
- Per repo instructions, I did not run repository tests.
- Remaining uncertainty is integration-level behavior on real ROCm hardware, since validation here is static plus focused unit coverage only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forecast feature robustness by sanitizing invalid values and ensuring proper data type handling.

* **Tests**
  * Expanded test coverage for forecasting behavior and feature sanitization.

* **Chores**
  * Updated repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->